### PR TITLE
Disable booking CTA

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -2,12 +2,8 @@
 
   <h1 id=logo><span>LiveWires</span></h1>
   <h2 class=tagline>technical activity holiday for 12–15s</h2>
-  <p class=tagline>last week of July 2019 • Salisbury, UK</p>
-  <div class="summary summary-in-hero">
+  <p class=tagline>a week in summer 2020 • Salisbury, UK</p>
 
-    <p>Enjoyed LiveWires 2019?<br><a href="http://downloads.livewires.org.uk/" target="blank">Download</a> what you made, and <a href="/reunion">join us at the reunion</a>!
-
-  </div>
 </div>
 <div class=heading>
 
@@ -211,12 +207,23 @@
 
       <p>LiveWires is part of <a href="https://content.scriptureunion.org.uk/holidays-events" target="blank" rel="noopener">Scripture Union Holidays</a>.
 
-      <ul class=footer-links>
-        <li><a href="http://downloads.livewires.org.uk/">Downloads</a>
-        <li><a href="https://www.instagram.com/livewireshol/" target="blank" rel="noopener">Instagram</a>
-        <li><a href="https://github.com/livewires" target="blank" rel="noopener">GitHub</a>
-        <li><a href="http://info.livewires.org.uk/helping/">Join the Team</a>
-      </ul>
+      <div class="col col-float-left col-footer">
+        <ul class="footer-links">
+
+          <li><a href="https://www.instagram.com/livewireshol/" target="blank" rel="noopener">Instagram</a>
+          <li><a href="https://github.com/livewires" target="blank" rel="noopener">GitHub</a>
+
+        </ul>
+      </div>
+      <div class="col col-right col-footer">
+        <ul class="footer-links">
+
+          <li><a href="http://downloads.livewires.org.uk/">Downloads</a>
+          <li><a href="http://livewires.org.uk/reunion">Reunion</a>
+          <li><a href="http://info.livewires.org.uk/helping/">Join the Team</a>
+
+        </ul>
+      </div>
 
   </div>
 </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -209,7 +209,7 @@
 
       <div class=bolt-white></div>
 
-      <p>LiveWires is part of <a href="http://www.scriptureunion.org.uk/ScriptureUnionHolidays/739.id" target="blank" rel="noopener">Scripture Union Holidays</a>.
+      <p>LiveWires is part of <a href="https://content.scriptureunion.org.uk/holidays-events" target="blank" rel="noopener">Scripture Union Holidays</a>.
 
       <ul class=footer-links>
         <li><a href="http://downloads.livewires.org.uk/">Downloads</a>

--- a/pages/index.html
+++ b/pages/index.html
@@ -2,9 +2,12 @@
 
   <h1 id=logo><span>LiveWires</span></h1>
   <h2 class=tagline>technical activity holiday for 12–15s</h2>
-  <p class=tagline>28th July–4th August • Salisbury, UK</p>
-  <a class=cta href="#book">How to Book</a>
+  <p class=tagline>last week of July 2019 • Salisbury, UK</p>
+  <div class="summary summary-in-hero">
 
+    <p>Enjoyed LiveWires 2019?<br><a href="http://downloads.livewires.org.uk/" target="blank">Download</a> what you made, and <a href="/reunion">join us at the reunion</a>!
+
+  </div>
 </div>
 <div class=heading>
 
@@ -193,14 +196,12 @@
 
   </div>
 
-  <a class="cta cta-final" href="http://www.scriptureunion.org.uk/3721881.id" target="blank" rel="noopener">Book Now</a>
-
 </div>
 <div class=summary>
 
-  <p>Still have questions? Get in touch!
-  <p>Email Steven &amp; Roger at <a href="mailto:leaders@livewires.org.uk">leaders@livewires.org.uk</a>,
-  or give them a call on <a href="tel:02033971111">020&nbsp;3397&nbsp;1111</a>.
+  <p>Bookings for 2020 aren’t open yet.
+  <p>Get in touch!<br>Email Steven &amp; Roger at <a href="mailto:leaders@livewires.org.uk">leaders@livewires.org.uk</a>,
+  or give us a call on <a href="tel:02033971111">020&nbsp;3397&nbsp;1111</a>.
 
 </div>
 <div class=footer>

--- a/pages/index.html
+++ b/pages/index.html
@@ -211,6 +211,7 @@
       <p>LiveWires is part of <a href="http://www.scriptureunion.org.uk/ScriptureUnionHolidays/739.id" target="blank" rel="noopener">Scripture Union Holidays</a>.
 
       <ul class=footer-links>
+        <li><a href="http://downloads.livewires.org.uk/">Downloads</a>
         <li><a href="https://www.instagram.com/livewireshol/" target="blank" rel="noopener">Instagram</a>
         <li><a href="https://github.com/livewires" target="blank" rel="noopener">GitHub</a>
         <li><a href="http://info.livewires.org.uk/helping/">Join the Team</a>

--- a/templates/theme.css
+++ b/templates/theme.css
@@ -147,6 +147,9 @@ hr {
   padding: 1rem 1rem 2rem;
   clear: both;
 }
+.col-footer {
+  padding: 0;
+}
 .summary {
   padding: 1rem;
 }

--- a/templates/theme.css
+++ b/templates/theme.css
@@ -150,6 +150,9 @@ hr {
 .summary {
   padding: 1rem;
 }
+.summary-in-hero {
+  text-align: center;
+}
 
 .row-paragraphs {
   padding: 1rem 0 0;


### PR DESCRIPTION
* It doesn't seem useful to have a big "Book Now" CTA when bookings aren't open yet, so I've removed that. Ideally we'd direct visitors to sign up to a mailing list to be notified when bookings open, but that can wait for a few days, I think.

* Second, I've added a link to the Downloads site in the footer, because that seems like an obvious thing to do.

* I've also added a link to the downloads and reunion pages prominently in the heading section. ~It looks a little bit like this~ I forgot Netlify does deploy previews :roll_eyes: 

* Finally, I've replaced the precise dates with "last week of July 2019", since I realised that we don't say anywhere up-front that it's a week long...

Fixes #6