### PR TITLE
Add Reunion form

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -10,7 +10,6 @@
 /book                   /#book               302
 /contact                /#book               302
 
-/reunion                http://info.livewires.org.uk/static/reunion/        302
 /ypq                    http://info.livewires.org.uk/static/ypq/ypq.html    302
 /day                    http://info.livewires.org.uk/about/day/             302
 /about/day              http://info.livewires.org.uk/about/day/             302

--- a/pages/index.html
+++ b/pages/index.html
@@ -200,4 +200,3 @@
   or give us a call on <a href="tel:02033971111">020&nbsp;3397&nbsp;1111</a>.
 
 </div>
-

--- a/pages/index.html
+++ b/pages/index.html
@@ -196,7 +196,7 @@
 <div class=summary>
 
   <p>Bookings for 2020 aren’t open yet.
-  <p>Get in touch!<br>Email Steven &amp; Roger at <a href="mailto:leaders@livewires.org.uk">leaders@livewires.org.uk</a>,
+  <p>Get in touch!<br>Email Steven &amp; Roger at <a href='mailto&#58;l&#101;a&#100;%65rs&#64;l&#105;%76ew&#105;re%&#55;3&#46;org&#46;%75%6B'>&#108;ea&#100;e&#114;s&#64;livew&#105;r&#101;s&#46;&#111;rg&#46;uk</a>,
   or give us a call on <a href="tel:02033971111">020&nbsp;3397&nbsp;1111</a>.
 
 </div>

--- a/pages/reunion.html
+++ b/pages/reunion.html
@@ -140,7 +140,7 @@ title: "LiveWires Reunion 2019"
 
       <label for="travel-contact"><strong>What is your emergency contact number?</strong> <span class="field-hint">(required)</span></label>
       <p class="field-hint">In case we need to contact your parents (or somone else suitable).</p>
-      <input type="tel" id="travel-contact" name="travel_contact" size="15" placeholder="07000 000 000" required>
+      <input type="tel" id="travel-contact" name="travel_contact" size="15" placeholder="07000 000 000">
 
     </fieldset>
     <fieldset>

--- a/pages/reunion.html
+++ b/pages/reunion.html
@@ -26,7 +26,7 @@ title: "LiveWires Reunion 2019"
 
     <p>This year’s reunion is at <a href="https://www.globe.church/">The Globe Church</a>, inside the Proclamation Trust building, near London Bridge.</p>
 
-    <p>We usually start around 1pm, and finish with pizza and a film from 5–7pm. There’ll be time for games, catching up, and a brief talk.</p>
+    <p>We’ll start at 1pm, and finish with pizza and a film from 5–7pm. There’ll be time for games, catching up, and a brief talk.</p>
 
     <p>Got questions? <a href='ma&#105;&#108;t&#111;&#58;&#37;72%65%75%6&#69;&#37;69on%&#52;0livew&#105;r%6&#53;s&#46;%&#54;F%72g&#46;u&#107;'>Email us</a>!</p>
 

--- a/pages/reunion.html
+++ b/pages/reunion.html
@@ -24,7 +24,7 @@ title: "LiveWires Reunion 2019"
 <div class="row row-has-map">
   <div class="col col-left">
 
-    <p>This year’s reunion is at <a href="https://www.globe.church/">The Globe Church</a>, near London Bridge.</p>
+    <p>This year’s reunion is at <a href="https://www.globe.church/">The Globe Church</a>, inside the Proclamation Trust building, near London Bridge.</p>
 
     <p>We usually start around 1pm, and finish with pizza and a film from 5–7pm. There’ll be time for games, catching up, and a brief talk.</p>
 
@@ -32,7 +32,7 @@ title: "LiveWires Reunion 2019"
 
   </div>
   <div class="col-image col-image-right col-image-map">
-    <iframe width=320 height=320 frameborder=0 style="border:0" src="https://www.google.com/maps/embed/v1/place?key=AIzaSyAv5a1ZxxGQZt13HodObWR5LASTyD_o_jg&q=place_id:ChIJVZVnGHgDdkgRKlerlfx6OVA&zoom=14" allowfullscreen></iframe>
+    <iframe width=320 height=320 frameborder=0 style="border:0" src="https://www.google.com/maps/embed/v1/place?key=AIzaSyAv5a1ZxxGQZt13HodObWR5LASTyD_o_jg&q=140–148+Borough+High+Street,+SE1+1LB&zoom=14&center=51.507,-0.087" allowfullscreen></iframe>
   </div>
 </div>
 <div class="heading" id="sign-up">

--- a/pages/reunion.html
+++ b/pages/reunion.html
@@ -1,0 +1,205 @@
+---
+title: "LiveWires Reunion 2019"
+
+---
+
+<div id="hero">
+
+  <a href="/" id="logo"><span>LiveWires</span></a>
+
+  <h2 class="tagline">Reunion 2019</h2>
+  <p class="tagline">Saturday 9th November • London Bridge, London</p>
+
+</div>
+<div class="heading">
+
+  <h1>Missing LiveWires already?</h1>
+
+</div>
+<div class="summary">
+
+  <p>Join us for a day in the autumn to catch up, have fun, and share memories of the summer.
+
+</div>
+<div class="row row-has-map">
+  <div class="col col-left">
+
+    <p>This year’s reunion is at <a href="https://www.globe.church/">The Globe Church</a>, near London Bridge.</p>
+
+    <p>We usually start around 1pm, and finish with pizza and a film from 5–7pm. There’ll be time for games, catching up, and a brief talk.</p>
+
+    <p>Got questions? <a href='ma&#105;&#108;t&#111;&#58;&#37;72%65%75%6&#69;&#37;69on%&#52;0livew&#105;r%6&#53;s&#46;%&#54;F%72g&#46;u&#107;'>Email us</a>!</p>
+
+  </div>
+  <div class="col-image col-image-right col-image-map">
+    <iframe width=320 height=320 frameborder=0 style="border:0" src="https://www.google.com/maps/embed/v1/place?key=AIzaSyAv5a1ZxxGQZt13HodObWR5LASTyD_o_jg&q=place_id:ChIJVZVnGHgDdkgRKlerlfx6OVA&zoom=14" allowfullscreen></iframe>
+  </div>
+</div>
+<div class="heading" id="sign-up">
+
+  <h1>Sign up now</h1>
+
+</div>
+<div class="summary">
+
+    <p>Tell us you’re coming below, or let us know you can’t make it.</p>
+
+</div>
+<form class="row row-form" method="post" action="http://info.livewires.org.uk/static/reunion/reunionpost.php">
+  <fieldset class="fieldset-left">
+
+    <label for="firstname"><strong>First name:</strong> <span class="field-hint">(required)</label>
+    <input type="text" id="firstname" name="firstname" size="18" placeholder="Bob" required>
+
+  </fieldset>
+  <fieldset class="fieldset-right">
+
+    <label for="secondname"><strong>Last name:</strong> <span class="field-hint">(required)</label>
+    <input type="text" id="secondname" name="secondname" size="18" placeholder="Smith" required>
+
+  </fieldset>
+  <fieldset>
+
+    <label for="email"><strong>Your email:</strong> <span class="field-hint">(required)</span></label>
+    <input type="email" id="email" name="email" size="30" placeholder="bob@example.com" required>
+
+  </fieldset>
+  <fieldset>
+
+    <legend><strong>Can you come to the reunion?</strong></legend>
+    <label for="coming-yes">
+      <input type="radio" id="coming-yes" name="coming" value="yes" required>
+      Yes
+    </label>
+    <label for="coming-no">
+      <input type="radio" id="coming-no" name="coming" value="no">
+      No
+    </label>
+
+  </fieldset>
+  <div id="form-coming-no" style="display: none;">
+    <div class=summary>
+
+      <p>Sorry to hear you can’t join us!</p>
+
+      <button class="cta" type=submit>Let us know</button>
+
+    </div>
+  </div>
+  <div id="form-coming-yes">
+    <br>
+    <h2 class="blue">Travel</h2>
+    <fieldset>
+
+      <label for="arrival"><strong>How will you get there?</strong></label>
+      <select id="arrival" name="arrival">
+        <option value="" disabled selected>Select one</option>
+        <option value="Train">Train</option>
+        <option value="Tube">Tube</option>
+        <option value="Car">Car</option>
+        <option value="Bus">Bus</option>
+        <option value="Other">Other</option>
+      </select>
+
+    </fieldset>
+    <fieldset id="fs-arrival-time">
+      
+      <label for="arrival-time"><strong>When will your <span id="arrival-method"></span> arrive?</strong></label>
+      <input type="text" id="arrival-time" name="arrival_time" size="8">
+
+    </fieldset>
+    <fieldset>
+
+      <label for="departure"><strong>How will you leave?</strong></label>
+      <select id="departure" name="departure">
+        <option value="" disabled selected>Select one</option>
+        <option value="Train">Train</option>
+        <option value="Tube">Tube</option>
+        <option value="Car">Car</option>
+        <option value="Bus">Bus</option>
+        <option value="Other">Other</option>
+      </select>
+
+    </fieldset>
+    <fieldset id="fs-departure-time">
+      
+      <label for="departure-time"><strong>What time will your <span id="departure-method"></span> depart?</strong></label>
+      <input type="text" id="departure-time" name="departure_time" size="8">
+
+    </fieldset>
+    <br>
+    <h2 class="blue">Your Details</h2>
+    <fieldset>
+
+      <label for="contact"><strong>What is your phone number?</strong></label>
+      <p class="field-hint">So we can contact you while you travel to the reunion.</p>
+      <input type="tel" id="contact" name="contact" size="15" placeholder="07000 000 000">
+
+    </fieldset>
+    <fieldset>
+
+      <label for="travel-contact"><strong>What is your emergency contact number?</strong> <span class="field-hint">(required)</span></label>
+      <p class="field-hint">In case we need to contact your parents (or somone else suitable).</p>
+      <input type="tel" id="travel-contact" name="travel_contact" size="15" placeholder="07000 000 000" required>
+
+    </fieldset>
+    <fieldset>
+
+      <legend><strong>Would you like a vegetarian meal?</strong></legend>
+      <label for="vegetarian-yes">
+        <input type="radio" id="vegetarian-yes" name="vegetarian" value="yes">
+        Yes
+      </label>
+      <label for="vegetarian-no">
+        <input type="radio" id="vegetarian-no" name="vegetarian" value="no">
+        No
+      </label>
+
+    </fieldset>
+    <fieldset>
+
+      <label for="health"><strong>Do you have any health or dietary requirements?</strong></label>
+      <p class="field-hint">Please tell us again, even if we knew about them in August.</p>
+      <textarea id="health" name="health" cols="42" rows="4"></textarea>
+
+    </fieldset>
+    <fieldset>
+
+      <button class="cta" type=submit>Sign Up</button>
+
+    </fieldset>
+  </div>
+</form>
+
+<script>
+function toggleDetails() {
+  var comingYes = document.querySelector('#coming-yes').checked 
+  document.querySelector('#form-coming-yes').style.display = comingYes ? '' : 'none'
+
+  var comingNo = document.querySelector('#coming-no').checked 
+  document.querySelector('#form-coming-no').style.display = comingNo ? '' : 'none'
+}
+document.querySelector('#coming-yes').onchange = toggleDetails
+document.querySelector('#coming-no').onchange = toggleDetails
+toggleDetails()
+
+function toggleArrivalTime() {
+  var arrival = document.querySelector('#arrival').value
+  var hasTime = arrival === 'Bus' || arrival === 'Tube' || arrival === 'Train'
+  document.querySelector('#fs-arrival-time').style.display = hasTime ? '' : 'none'
+
+  document.querySelector('#arrival-method').textContent = arrival.toLowerCase()
+}
+document.querySelector('#arrival').onchange = toggleArrivalTime
+toggleArrivalTime()
+
+function toggleDepartureTime() {
+  var departure = document.querySelector('#departure').value
+  var hasTime = departure === 'Bus' || departure === 'Tube' || departure === 'Train'
+  document.querySelector('#fs-departure-time').style.display = hasTime ? '' : 'none'
+
+  document.querySelector('#departure-method').textContent = departure.toLowerCase()
+}
+document.querySelector('#departure').onchange = toggleDepartureTime
+toggleDepartureTime()
+</script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,7 +71,7 @@
           <ul class="footer-links">
 
             <li><a href="http://downloads.livewires.org.uk/">Downloads</a>
-            <li><a href="http://livewires.org.uk/reunion">Reunion</a>
+            <li><a href="/reunion/">Reunion</a>
             <li><a href="http://info.livewires.org.uk/helping/">Join the Team</a>
 
           </ul>

--- a/templates/theme.css
+++ b/templates/theme.css
@@ -5,7 +5,7 @@
 
 body, div, p, textarea, pre, ul, ol, li, blockquote, hr,
 table, tbody, thead, tr, td, th,
-h1, h2, h3, h4, h5, a, button, input {
+h1, h2, h3, h4, h5, a, button, fieldset, legend, select {
   margin: 0;
   padding: 0;
   border: 0;
@@ -15,7 +15,7 @@ h1, h2, h3, h4, h5, a, button, input {
   text-decoration: none;
   background: transparent;
   color: inherit;
-  -webkit-appearance: none;
+  appearance: none;
   outline: none;
 }
 
@@ -40,7 +40,7 @@ body {
   background: #f8f8f8;
 }
 
-h1, h2, .cta, .tagline {
+h1, h2, h3, .cta, .tagline, .menu, fieldset strong {
   font-family: Nexa, -apple-system, Helvetica Neue, Arial, Helvetica, sans-serif;
   font-weight: bold;
 }
@@ -105,8 +105,12 @@ p a:hover {
   margin: 1rem auto 2rem;
 }
 
-.tagline {
+.tagline, .blue {
   color: #2ba8d8;
+}
+
+
+.tagline {
   text-align: center;
   margin: 0 0 0.5rem;
   text-shadow: 0 0 1px rgba(255,255,255, 0.2)
@@ -362,6 +366,7 @@ hr {
   background-color: #104d7a;
 }
 
+
 /* footer */
 
 .footer {
@@ -411,3 +416,70 @@ hr {
 }
 
 
+/* forms */
+
+.row-form {
+  padding: 0 1rem;
+}
+
+fieldset {
+  margin-top: 1rem;
+}
+
+@media screen and (min-width: 46rem) {
+  fieldset {
+    clear: both;
+  }
+  .fieldset-left {
+    float: left;
+    width: 50%;
+    padding-right: 0.5rem;
+  }
+  .fieldset-right {
+    margin-left: 50%;
+    clear: none;
+    padding-left: 0.5rem;
+    padding-top: 1rem;
+  }
+}
+
+legend, label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+label {
+  cursor: pointer;
+}
+
+input[type=text],
+input[type=email],
+input[type=tel],
+select,
+textarea {
+  display: block;
+  appearance: none;
+  -webkit-appearance: none;
+  outline: none;
+  background: #fff;
+  color: #222;
+  width: 100%;
+  border: 1px solid #ccc;
+  font: inherit;
+  font-size: 1rem;
+  border-radius: 0.25rem;
+  padding: 0.5rem 1rem;
+  transition: border-color .3s ease-in;
+}
+input[type=text]:focus,
+input[type=email]:focus,
+input[type=tel]:focus,
+select:focus,
+textarea:focus {
+  border-color: #2ba8d8;
+  box-shadow: 0 0 0.25rem rgba(43, 168, 216, 0.5);
+}
+
+.field-hint {
+  color: #333;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
The current Reunion page is still on the old domain, doesn't contain much information, is hard to use on mobile, and I'm worried that people may not (bother to) complete it correctly.

This replaces the existing redirect with a brand-new reunion page. The new page POSTs the form to the existing `reunionpost.php` endpoint. This seems to work just fine, since there's no XSS / CORS protection on that endpoint (nor does there really need to be).

I've kept the same form structure, but made it prettier and more mobile-friendly. I might have liked to simplify the questions themselves, but we can do that next year.