### PR TITLE
Restore booking CTA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 venv/
 _site/
+*.pyc

--- a/pages/index.html
+++ b/pages/index.html
@@ -8,10 +8,11 @@ og_description: "Start your summer with a week learning about Jesus and technolo
 <div id=hero>
 
   <h1 id=logo><span>LiveWires</span></h1>
-  <h2 class=tagline>technical activity holiday for 12–15s</h2>
-  <p class=tagline>2nd–9th August 2020 • Salisbury, UK</p>
-  <a class=cta href="#book">How to Book</a>
-
+  <div class="row row-in-hero col-paragraph">
+    <h2 class=tagline>technical activity holiday for 12–15s</h2>
+    <p class=tagline>2nd–9th August 2020 • Salisbury, UK</p>
+    <a class="cta" href="#book">How to Book</a>
+  </div>
 </div>
 <div class=heading>
 
@@ -200,7 +201,7 @@ og_description: "Start your summer with a week learning about Jesus and technolo
 
   </div>
 
-  <a class="cta cta-final" href="https://content.scriptureunion.org.uk/holiday/livewires" target="blank" rel="noopener" id="book-now">Book Now</a>
+  <a class="cta" href="https://content.scriptureunion.org.uk/holiday/livewires" target="blank" rel="noopener" id="book-now">Book Now</a>
 
 </div>
 <div class="row row-paragraphs">

--- a/pages/index.html
+++ b/pages/index.html
@@ -10,6 +10,7 @@ og_description: "Start your summer with a week learning about Jesus and technolo
   <h1 id=logo><span>LiveWires</span></h1>
   <h2 class=tagline>technical activity holiday for 12–15s</h2>
   <p class=tagline>2nd–9th August 2020 • Salisbury, UK</p>
+  <a class=cta href="#book">How to Book</a>
 
 </div>
 <div class=heading>
@@ -187,11 +188,6 @@ og_description: "Start your summer with a week learning about Jesus and technolo
   <h1>How to book</h1>
 
 </div>
-<div class=summary>
-
-  <p>Bookings for 2020 aren’t open yet.
-
-</div>
 <div class="row row-paragraphs">
   <div class="col col-float-left col-paragraph">
 
@@ -200,14 +196,18 @@ og_description: "Start your summer with a week learning about Jesus and technolo
   </div>
   <div class="col col-right col-paragraph">
 
-    <p>You can book on Scripture Union’s website. SU have been running summer holidays for over a hundred years.
+    <p>You can book on Scripture Union’s website. <a href="https://content.scriptureunion.org.uk/holidays-events">Scripture Union</a> have been running summer holidays for over a hundred years.
 
   </div>
 
+  <a class="cta cta-final" href="https://content.scriptureunion.org.uk/holiday/livewires" target="blank" rel="noopener" id="book-now">Book Now</a>
+
 </div>
-<div class=summary>
+<div class="row row-paragraphs">
+  <div class="col col-paragraph col-paragraph-center">
 
-  <p>Get in touch! Email Steven &amp; Roger at <a href='mailto&#58;l&#101;a&#100;%65rs&#64;l&#105;%76ew&#105;re%&#55;3&#46;org&#46;%75%6B'>&#108;ea&#100;e&#114;s&#64;livew&#105;r&#101;s&#46;&#111;rg&#46;uk</a>,
-  or give us a call on <a href="tel:02033971111">020&nbsp;3397&nbsp;1111</a>.
+    <p>Still have questions? Get in touch! Email Steven &amp; Roger at <a href='mailto&#58;l&#101;a&#100;%65rs&#64;l&#105;%76ew&#105;re%&#55;3&#46;org&#46;%75%6B'>&#108;ea&#100;e&#114;s&#64;livew&#105;r&#101;s&#46;&#111;rg&#46;uk</a>,
+    or give them a call on <a href="tel:02033971111">020&nbsp;3397&nbsp;1111</a>.
 
+  </div>
 </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,17 +4,8 @@
     <meta charset=utf-8>
     <meta name=viewport content="width=device-width, initial-scale=1, viewport-fit=cover">
 
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet">
     <style>
-    /* latin */
-    @font-face {
-      font-family: 'Open Sans';
-      font-style: normal;
-      font-weight: 400;
-      font-display: block;
-      src: local('Open Sans Regular'), local('OpenSans-Regular'), url(https://fonts.gstatic.com/s/opensans/v16/mem8YaGs126MiZpBA-UFVZ0bf8pkAg.woff2) format('woff2'), url(https://fonts.gstatic.com/s/crimsontext/v9/wlp2gwHKFkZgtmSR3NB0oRJfbwhV.woff) format('woff');;
-      unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-    }
-
     @font-face {
       font-family: 'Nexa';
       src: url('/assets/font/subset-NexaBold.woff2') format('woff2'), url('/assets/font/subset-NexaBold.woff') format('woff');

--- a/templates/base.html
+++ b/templates/base.html
@@ -86,7 +86,6 @@
           <ul class="footer-links">
 
             <li><a href="http://downloads.livewires.org.uk/">Downloads</a>
-            <li><a href="/reunion/">Reunion</a>
             <li><a href="http://info.livewires.org.uk/helping/">Join the Team</a>
 
           </ul>

--- a/templates/theme.css
+++ b/templates/theme.css
@@ -141,6 +141,9 @@ hr {
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
 }
+.row-in-hero {
+  margin: 0 auto;
+}
 .row:after {
   content: "";
   display: block;
@@ -358,9 +361,6 @@ hr {
   border-radius: 2px;
   text-decoration: none;
   transition: all .2s;
-}
-.cta-final {
-  margin: 3rem auto 0;
 }
 
 .cta:hover {

--- a/templates/theme.css
+++ b/templates/theme.css
@@ -157,9 +157,6 @@ hr {
 .summary {
   padding: 1rem;
 }
-.summary-in-hero {
-  text-align: center;
-}
 
 .col-paragraph {
   padding: 0 1rem;
@@ -181,6 +178,9 @@ hr {
   .summary {
     margin-left: 16.6%;
     margin-right: 16.6%;
+    text-align: center;
+  }
+  .col-paragraph-center {
     text-align: center;
   }
 


### PR DESCRIPTION
This restores the "Book Now" CTA which we removed in #7 and 7146774f0b8224f8af743bba568c18cee97d8613. I've made some style tweaks to improve the layout a little.

I've dropped the "Reunion" link from the footer, since the reunion has already happened for this year.