### PR TITLE
Drop "Online" from title

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -1,5 +1,5 @@
 ---
-title: "LiveWires Online: technical activity week for 12–15s"
+title: "LiveWires: technical activity week for 12–15s"
 social_title: "technical activity week for 12–15s"
 social_image: "/assets/livewires-og.jpg"
 description: "LiveWires is a technical activity week for 12–15s. Start your summer learning about Jesus and technology."
@@ -7,7 +7,7 @@ og_description: "Start your summer with a week learning about Jesus and technolo
 ---
 <div id=hero>
 
-  <h1 id=logo><span>LiveWires Online</span></h1>
+  <h1 id=logo><span>LiveWires</span></h1>
   <div class="row row-in-hero col-paragraph">
     <h2 class=tagline>Technical activity week for 12–15s</h2>
     <p class=tagline>7th–14th August 2022 • Chafyn Grove School, Salisbury</p>


### PR DESCRIPTION
Are we still "LiveWires Online", or can we drop this from the name?